### PR TITLE
Update to use Git Credential Manager Core

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
 # Taps
 tap 'homebrew/cask'
 tap 'homebrew/cask-fonts'
+tap 'microsoft/git'
 tap 'owenvoke/casks'
 tap 'teamookla/speedtest'
 
@@ -36,3 +37,6 @@ cask 'font-roboto'
 
 # Speedtest CLI
 brew 'teamookla/speedtest/speedtest'
+
+# Git Credential Manager
+cask 'microsoft/git/git-credential-manager-core'

--- a/gitconfig
+++ b/gitconfig
@@ -45,3 +45,9 @@
     publish = !git push --set-upstream origin \"$(git rev-parse --abbrev-ref HEAD)\"
     s = status
     staged = diff --staged
+
+[credential]
+    helper = manager-core
+
+[credential "https://dev.azure.com"]
+    useHttpPath = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

I'm kind of hoping that the credential manager gets added to Brew core instead of having to use another tap.

- [x] I have read the **[CONTRIBUTING](https://github.com/owenvoke/.github/blob/master/CONTRIBUTING.md)** document.
